### PR TITLE
Set response content type to application/rss+xml

### DIFF
--- a/src/bundle/Controller/RssFeedViewController.php
+++ b/src/bundle/Controller/RssFeedViewController.php
@@ -82,7 +82,7 @@ class RssFeedViewController extends Controller
                 )
             );
 
-            $response->headers->set('Content-Type', 'application/xml; charset=utf-8');
+            $response->headers->set('Content-Type', 'application/rss+xml; charset=utf-8');
 
             return $response;
         } else {


### PR DESCRIPTION
Q | A
-- | --
Branch? | master
Bug fix? | yes
New feature? | no
Deprecations? | no
Tickets |  
License | MIT
Doc PR |  

I'm facing this kind of exception:
```
Error on line 1 at column 10: XML declaration allowed only at the start of the
document
Below is a rendering of the page up to the first error.
```

I just changed the MIME type to `application/rss+xml` and for whatever reason my problem has been solved.